### PR TITLE
Remove unnecessary Shutdown() method

### DIFF
--- a/Heat/Entry.cs
+++ b/Heat/Entry.cs
@@ -89,11 +89,6 @@ namespace Spectrum.Plugins.Heat
             _settings.Save();
         }
 
-        public void Shutdown()
-        {
-
-        }
-
         // Utilities, taken from Spectrum's LocalVehicle
         private static CarLogic GetCarLogic()
         {


### PR DESCRIPTION
Ciastex pointed out it's not needed anymore.